### PR TITLE
fix hyperlink in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add the plugin to your `project.clj`:
 
 This plugin accepts the following pattern `clojure-lsp <command> "<options>"`.
 
-For more information on all available commands and options, Check the [API documentation](https://clojure-lsp.io/api/).
+For more information on all available commands and options, Check the [API documentation](https://clojure-lsp.io/api/what-is-it/).
 
 ### lein CLI
 


### PR DESCRIPTION
Fixes the [clojure-lsp-api](https://clojure-lsp.io/api/what-is-it/) hyperlink, which was recently changed. See also clojure-lsp/clojure-lsp#1513