### PR TITLE
Enable pedantic? abort

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,9 +4,11 @@
   :license {:name "MIT"
             :url "https://opensource.org/licenses/MIT"}
   :eval-in-leiningen true
-  :pedantic? :warn
+  :pedantic? :abort
   :deploy-repositories [["clojars" {:url           "https://clojars.org/repo"
                                     :username      :env/clojars_username
                                     :password      :env/clojars_password
                                     :sign-releases false}]]
+  :managed-dependencies [[com.fasterxml.jackson.core/jackson-core "2.15.2"]
+                         [org.clojure/tools.cli "1.0.219"]]
   :dependencies [[com.github.clojure-lsp/clojure-lsp-server "2023.08.06-00.28.06"]])


### PR DESCRIPTION
This allows the plugin to be used in projects that also use `:pedantic? :abort`.

Fixes https://github.com/clojure-lsp/lein-clojure-lsp/issues/7