### PR TITLE
Fix leiningen.clojure-lsp.binary/download-server? algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix download server file predicate to handle file not found scenarios.
+
 ## 2.0.1
 
 - Fix cached downloaded binary to check if downloaded version matches the current version in plugin.

--- a/src/leiningen/clojure_lsp/binary.clj
+++ b/src/leiningen/clojure_lsp/binary.clj
@@ -87,8 +87,8 @@
     @p))
 
 (defn ^:private download-server? [server-path server-version-path version]
-  (or (not (.exists server-path))
-      (not= (slurp server-version-path) version)))
+  (not= version
+        (try (slurp server-version-path) (catch Exception _ :error-checking-local-version))))
 
 (defn run! [args]
   (let [server-path (server-path)


### PR DESCRIPTION
Current implementation of `download-server?` function in `binary.clj` file is not working as expected.
When the file doesn't exist, it evaluates to `true`, making the second `or` condition to be evaluated, thus raising a FileNotFound exception.
This PR fixes the algorithm in order to properly handle when the file doesn't exist.