### PR TITLE
Commit resources/CLOJURE_LSP_VERSION on tag-patch-for-version

### DIFF
--- a/scripts/lein_clojure_lsp/ci.clj
+++ b/scripts/lein_clojure_lsp/ci.clj
@@ -50,7 +50,7 @@
   (let [new-tag (get-patched-tag)]
     (replace-tag new-tag)
     (add-changelog-entry new-tag (str "Bump clojure-lsp to " version))
-    (shell "git add project.clj README.md CHANGELOG.md")
+    (shell "git add project.clj README.md CHANGELOG.md resources/CLOJURE_LSP_VERSION")
     (shell (format "git commit -m \"Release: %s\"" new-tag))
     (shell (str "git tag " new-tag)))
   (shell "git push origin HEAD")


### PR DESCRIPTION
If the file isn't committed, it won't bump the clojure-lsp server.